### PR TITLE
Add: New tools | Evil-WinRM and CDK to Post-Exploitation periodic-table-tools.md

### DIFF
--- a/periodic-table-tools.md
+++ b/periodic-table-tools.md
@@ -88,7 +88,7 @@ Feel free to **suggest replacements** by editing this file and submitting a Pull
 | pP   | PetitPotam                   | https://github.com/topotam/PetitPotam | 
 | Def  | dnschef                      | https://github.com/iphelix/dnschef |
 | Im   | impacket                     | https://github.com/fortra/impacket |
-| Ws   | websploit                    | https://github.com/f4rih/websploit |
+| Ew   | Evil-WinRM         | https://github.com/Hackplayers/evil-winrm |
 | X-er | xsser                        | https://github.com/epsylon/xsser |
 | UAC  | UACME                        | https://github.com/hfiref0x/UACME |
 | JW   | jwt_tool                     | https://github.com/ticarpi/jwt_tool |
@@ -127,10 +127,10 @@ Feel free to **suggest replacements** by editing this file and submitting a Pull
 | WMI  | wmiexec-PRO        | https://github.com/XiaoliChan/wmiexec-Pro |
 | Cs   | Cobalt Strike      | https://www.cobaltstrike.com/ |
 | RC   | RunasCs            | https://github.com/antonioCoco/RunasCs |
-| nom  | ldapnomnom         | https://github.com/lkarlslund/ldapnomnom |
-| Vi   | Villain            | https://github.com/t3l3machus/Villain |
-| Ew   | Evil-WinRM         | https://github.com/Hackplayers/evil-winrm |
 | CDk  | CDK                | https://github.com/cdk-team/CDK |
+| Vi   | Villain            | https://github.com/t3l3machus/Villain |
+
+
 
 ## 🟩 Frameworks & Standards (16 elements)
 

--- a/periodic-table-tools.md
+++ b/periodic-table-tools.md
@@ -129,7 +129,8 @@ Feel free to **suggest replacements** by editing this file and submitting a Pull
 | RC   | RunasCs            | https://github.com/antonioCoco/RunasCs |
 | nom  | ldapnomnom         | https://github.com/lkarlslund/ldapnomnom |
 | Vi   | Villain            | https://github.com/t3l3machus/Villain |
-
+| Ew   | Evil-WinRM         | https://github.com/Hackplayers/evil-winrm |
+| CDk  | CDK                | https://github.com/cdk-team/CDK |
 
 ## 🟩 Frameworks & Standards (16 elements)
 


### PR DESCRIPTION
* Added Evil-WinRM as the go-to WinRM shell for Windows lateral movement.  
-A stable, stealthy foothold with built-in support for file upload/download, PowerShell script execution, credential passing, and in-memory tooling, ideal for living-off-the-land operations after initial compromise.

* Added CDK (Container Attack Toolkit) for Docker/K8s post-exploitation (escape, privesc, lateral).
-CDK brings post-exploitation into the cloud realm, it simulates real attacker techniques in AWS, Azure, GCP, and Kubernetes, something no other tool in the list currently offers.